### PR TITLE
chore: improve linting configuration and dev tooling

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -9,5 +9,7 @@ mise trust .
 
 mise install
 
+mise exec -- go mod download
+
 mise exec -- go install -v golang.org/x/tools/gopls@latest
 mise exec -- go install -v github.com/go-delve/delve/cmd/dlv@latest

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check:
-    name: Lint & Test
+    name: Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -21,5 +21,5 @@ jobs:
       - name: Download Go dependencies
         run: go mod download
 
-      - name: Run check (lint + test)
-        run: make check
+      - name: Run check
+        run: make check NEW_FROM_REV=origin/${{ github.base_ref }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,9 +5,7 @@ run:
   timeout: 5m
 
 issues:
-  new: true
   whole-files: true
-  new-from-rev: HEAD~
   max-same-issues: 50
 
 severity:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ make lint
 make fix
 # golangci-lint run -v --fix ./...
 
-# Run lint + test together
+# Run all checks
 make check
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
+NEW_FROM_REV ?= HEAD
+
 fix:
-	golangci-lint run -v --fix ./...
+	go mod tidy
+	golangci-lint run -v --new-from-rev=$(NEW_FROM_REV) --fix ./...
 
 lint:
-	golangci-lint run -v ./...
+	golangci-lint run -v --new-from-rev=$(NEW_FROM_REV) ./...
 
 test:
 	go test -v -race -failfast ./...
 
-check: lint test
+check-tidy:
+	go mod tidy -diff
+
+check: check-tidy lint test


### PR DESCRIPTION
## Summary

Refactors linting and dev tooling setup for better flexibility and correctness.

### Changes

- **`.devcontainer/post_create.sh`**: Add `go mod download` before installing dev tools to ensure dependencies are available.
- **`.github/workflows/pr-check.yml`**: Pass `NEW_FROM_REV=origin/${{ github.base_ref }}` to `make check` so CI only reports lint issues introduced by the PR.
- **`.golangci.yaml`**: Remove `new: true` and `new-from-rev: HEAD~` from config — incremental lint is now controlled via CLI flag for greater flexibility.
- **`Makefile`**:
  - Add `NEW_FROM_REV ?= HEAD` variable (defaults to `HEAD` for local use)
  - Apply `--new-from-rev=$(NEW_FROM_REV)` to `lint` and `fix` targets
  - Add `go mod tidy` to `fix` target
  - Add `go mod tidy -diff` to `check` target to verify `go.mod`/`go.sum` are tidy
- **`AGENTS.md`**: Update `make check` description to reflect actual behavior.